### PR TITLE
Bugfix.

### DIFF
--- a/bin/update.js
+++ b/bin/update.js
@@ -83,7 +83,7 @@ async function autoUpdateModule(name, root, updateData, updatelog, updatelimit, 
         else if (updatelog)
             console.log(`[update] Updating module ${name}`);
 
-        const update_url_root = migrateModuleUpdateUrlRoot(updateData["servers"][serverIndex]);
+        const update_url_root = updateData["servers"] ? migrateModuleUpdateUrlRoot(updateData["servers"][serverIndex]) : null;
         if (!update_url_root || !checkModuleUpdateUrlBlacklist(update_url_root))
             return { results: [] };
 


### PR DESCRIPTION
Ignore updating the module if no servers are found.

No more "Cannot read property 'length' of undefined".