### PR TITLE
Add support for non-Windows users to GPKManager

### DIFF
--- a/node_modules/tera-client-interface/GPKManager.js
+++ b/node_modules/tera-client-interface/GPKManager.js
@@ -2,6 +2,7 @@ const mui = require('tera-toolbox-mui').DefaultInstance;
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
+const { execFileSync } = require('child_process');
 
 function forcedirSync(dir) {
     const sep = path.sep;
@@ -51,6 +52,9 @@ class GPKManager {
         this.GPKFolderName = GPKFolderName;
         this.installedFiles = {};
         this.hasShownSymlinkWarning = false;
+        // For non-Windows users
+        this.cachedPaths = {};
+        this.pathValid = false;
     }
 
     destructor() {
@@ -58,7 +62,27 @@ class GPKManager {
     }
 
     getGPKFolderPath(clientFolder) {
-        return path.join(clientFolder, 'S1Game', 'CookedPC', this.GPKFolderName);
+        if (process.platform === 'win32')
+            return path.join(clientFolder, 'S1Game', 'CookedPC', this.GPKFolderName);
+
+        // Non-Windows users using Wine
+
+        // Check if PATH is valid
+        if (!this.pathValid) {
+            try { execFileSync('which', [ 'winepath' ]); this.pathValid = true; }
+            catch (e) { throw new Error('`winepath` not found within PATH'); }
+        }
+
+        let winePath;
+        // Since winepath can be slow (upwards of 2 seconds each time) if WINEPREFIX is wrong, cache calls to it
+        if (!(winePath = this.cachedPaths[clientFolder]))
+            winePath = this.cachedPaths[clientFolder] = execFileSync('winepath', [ '-u', clientFolder ]).toString().trim();
+
+        // Check if WINEPREFIX was valid
+        if (!fs.existsSync(winePath))
+            throw new Error('TERA not found within WINEPREFIX (Is WINEPREFIX set correctly?)');
+
+        return path.join(winePath, 'S1Game', 'CookedPC', this.GPKFolderName);
     }
 
     getFullPath(clientFolder, filename) {


### PR DESCRIPTION
Have been using this for the past couple days and have had no issues. Overhauls GPKManager::getGPKFolderPath to convert the Windows path that the interface gives into the correct Mac/Linux path via Wine's `winepath` utility and caches the result just in case things go wrong.